### PR TITLE
media uploads: get correct value from EXIF

### DIFF
--- a/app/models/media_file.rb
+++ b/app/models/media_file.rb
@@ -260,8 +260,7 @@ class MediaFile < ActiveRecord::Base
       meta_data.merge!(exif_hash)
     end
     # FIXME - We are inserting image-specific data into a model that is generic in intent, for the convenience of it all.
-    # Apparently IFD0 is not the best fit (some files don't contain it), perhaps we should use the Composite:ImageSize tag, till we get rid of these columns..
-    img_x, img_y = exif_hash["Composite:ImageSize"].split("x")
+    img_x, img_y = exif_hash["Composite:ImageSize"]["val"].split("x")
     update_attributes(:width => img_x, :height => img_y)
   end
 


### PR DESCRIPTION
It seems the underlying data structure changed,
so it was just a matter of getting the correct value.
