### PR TITLE
doc: review process: clarification regarding git(hub) conventions

### DIFF
--- a/doc/development/submit_and_review_process.md
+++ b/doc/development/submit_and_review_process.md
@@ -73,5 +73,6 @@ Relaxed Process for the Madek Core-Team
 This section describes a relaxed process applicable to the core Madek-Team to
 the end of avoiding exzessive effort during development and in particular with
 respect of merging commits. Developers will commit a unit of work them self and
-immediately when the work is finished. Reviews will be added afterwards.
-
+immediately when the work is finished. Reviews will be added afterwards. 
+To explicitly state this, these commits should include a `Signed-off-by` with 
+their own name.


### PR DESCRIPTION
This is also a demo pull request according to the proposed changes.
I am not sure myself about 5925c9c, though.

This ends the formal introduction (in case the ticket would be a few days old), by convention I could include a proposed git log message, but the single commit are named to work well in the auto generated message of a squash-merge. Note the Pivotal ID, it will deliver the ticket if included in the message and is pushed to github.

---
- demand pull requests
- use "Signed-off-by"
- 'relaxed core' has to self-sign

delivers [#84365862]
