### PR TITLE
ci: git checks

### DIFF
--- a/.cider-ci.yml
+++ b/.cider-ci.yml
@@ -1,6 +1,7 @@
-_cider-ci_include: 
+_cider-ci_include:
   - .cider-ci/jobs/code-check.yml
   - .cider-ci/jobs/coverage.yml
   - .cider-ci/jobs/deploy.yml
+  - .cider-ci/jobs/meta.yml
   - .cider-ci/jobs/tests-jruby.yml
   - .cider-ci/jobs/tests-mri.yml

--- a/.cider-ci/jobs/meta.yml
+++ b/.cider-ci/jobs/meta.yml
@@ -1,0 +1,35 @@
+jobs:
+
+  meta:
+
+    name: Meta
+    description: |
+      Tasks that rely on external (out-of-repository) state.
+      Their state is not as fixed as in the other Jobs,
+      so it might change over time.
+
+    run-on:
+    - type: branch
+      include-match: ^.*madek-v3.*$
+
+    context:
+      task-defaults:
+        max-auto-trials: 1
+        traits:
+          linux: true
+
+      tasks:
+        git_log:
+          scripts:
+            main:
+              body: "git log -n5"
+        git_branch_current:
+          name: "git tree contains latest commit from origin/HEAD"
+          scripts:
+            main:
+              body: "./dev/test/check-if-branch-current.sh"
+        git_submodules:
+          name: "git submodules trees all contain latest commit from origin/HEAD"
+          scripts:
+            main:
+              body: "./dev/test/check-if-submodules-current.sh"

--- a/dev/test/check-if-branch-current.sh
+++ b/dev/test/check-if-branch-current.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -ex
+
+# check if your tree still contains the current commit from master
+git rev-list --children HEAD | grep -q "$(git rev-parse origin/HEAD)"

--- a/dev/test/check-if-submodules-current.sh
+++ b/dev/test/check-if-submodules-current.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -ex
+
+# like `check-if-branch-current`, but for all the submodules, recursive.
+
+# make sure all submodules are checked out
+# WARNING: test is false-positive without this:
+git submodule update --init --recursive
+
+# <git ✨>
+# the lowercase variables come from git
+# lines explained in order:
+# - go to superproject (for this level of recursion)
+# - get current commit from remote master
+# - get current commit of submodule in current commit from remote master
+# - go to the submodule
+# - check that the current submodule commit is still contained in tree
+git submodule foreach --recursive '\
+  cd "${toplevel}" \
+  && SUPER_HASH="$(git rev-parse origin/HEAD)" \
+  && SUB_HASH=$(git rev-parse ${SUPER_HASH}:${path}) \
+  && cd "${path}" \
+  && git rev-list --children HEAD | grep -q "^${SUB_HASH}"'
+# </git ✨>


### PR DESCRIPTION
@DrTom please review. should now be easier to understand what is happening.

example runs for the submodules check to see how the cases look:
- it [FAILS](http://ci3.zhdk.ch/cider-ci/ui/workspace/trials/b2564b1e-16ae-41bc-80dd-074325a1187b#main)  if a submodule can't be checked out (not pushed)
- it [FAILS](http://ci3.zhdk.ch/cider-ci/ui/workspace/trials/bfa9da18-e82e-44fc-801b-5d45105ff672#main) if a submodule referenced a commit that is not "current" ("based on" the commit for this module in origin/HEAD of the project that references it
- … and it is [OK](http://ci3.zhdk.ch/cider-ci/ui/workspace/trials/2d30e11f-969a-4a83-83ef-53bd509275b6#main) if a submobule references a commit that is "ahead" of "current"