### PR TITLE
fix rerun script caused by missing db dump file

### DIFF
--- a/db/personas.100.pgbin
+++ b/db/personas.100.pgbin
@@ -1,0 +1,1 @@
+../engines/datalayer/db/personas.100.pgbin


### PR DESCRIPTION
I came across with the problem when I tried to restore db data from a dump file on my local machine.
To fix it I created a symbolic link to `personas.100.pgbin` pointing to a dump file under `datalayer/db` directory.