### PR TITLE
Updated history to version 1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "coffee-reactify": "4.0.0",
     "coffee-script": "1.10.0",
     "hashblot": "0.4.5",
-    "history": "1.12.1",
+    "history": "1.12.2",
     "hogan.js": "3.0.2",
     "jquery": "2.1.4",
     "jquery-ujs": "1.0.4",


### PR DESCRIPTION
:rocket:

history just published version 1.12.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 6 commits (ahead by 6, behind by 0).

- [fbb559c](https://github.com/rackt/history/commit/fbb559c7e6b9559eb18f0a92b956ff2a5648be83): Version 1.12.2
- [b9a1db7](https://github.com/rackt/history/commit/b9a1db753d5fc09303b166bc3af04d08b7c868fa): Update CHANGES
- [6ed20f5](https://github.com/rackt/history/commit/6ed20f57ed8f5c8fe215bbdebf30f358cfc5979f): Refactor test
- [7012f9b](https://github.com/rackt/history/commit/7012f9b697f614c1d412926b04079d6b86732757): Fix hash support
- [795c75f](https://github.com/rackt/history/commit/795c75ff24a1bcbb3cef487d665922a86c5a9f7e): Update comments
- [0308d24](https://github.com/rackt/history/commit/0308d24ad688d239311c7c1fe36a9368c95e78ca): Update CHANGES

See the [full diff](https://github.com/rackt/history/compare/0f65e2a1099afb6eec87ebce67971b570fdf4ee5...fbb559c7e6b9559eb18f0a92b956ff2a5648be83).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>