### PR TITLE
fix: media file export sets extension in file name if given in meta data

### DIFF
--- a/app/controllers/media_files_controller.rb
+++ b/app/controllers/media_files_controller.rb
@@ -19,7 +19,8 @@ class MediaFilesController < ApplicationController
     authorize(media_file)
     serve_file(
       media_file.original_store_location,
-      content_type: media_file.content_type)
+      content_type: media_file.content_type,
+      filename: media_file.filename)
   end
 
   def download_by_access_hash
@@ -28,7 +29,8 @@ class MediaFilesController < ApplicationController
     media_file = MediaFile.find_by!(id: id_param, access_hash: access_hash_param)
     serve_file(
       media_file.original_store_location,
-      content_type: media_file.content_type)
+      content_type: media_file.content_type,
+      filename: media_file.filename)
   end
 
   def id_param

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -9,7 +9,30 @@ class PreviewsController < ApplicationController
     # NOTE: could be optimized but it's tricky because of the permissions.
     # It's safe now because we do this a) after authorization b) with public=false
     if stale?(preview, public: false, template: false)
-      serve_file(preview.file_path, content_type: preview.content_type)
+      serve_file(
+        preview.file_path,
+        content_type: preview.content_type,
+        filename: download_filename(preview))
     end
+  end
+
+  private
+
+  def download_filename(preview)
+    media_file = preview.media_file
+    return unless (media_file and media_file.filename)
+
+    "#{media_file.filename}#{size(preview)}#{extension(preview)}"
+  end
+
+  def size(preview)
+    return '' unless (preview.width and preview.height)
+
+    # for example '.640x480'
+    ".#{preview.width}x#{preview.height}"
+  end
+
+  def extension(preview)
+    File.extname(preview.filename)
   end
 end

--- a/spec/features/media_entry/media_entry_export_spec.rb
+++ b/spec/features/media_entry/media_entry_export_spec.rb
@@ -90,6 +90,55 @@ feature 'Resource: MediaEntry' do
       expect(Digest::SHA256.hexdigest(File.read(downloaded_file)))
         .to eq(Digest::SHA256.hexdigest(File.read(wanted_file)))
     end
+
+    it 'Check filename original file', browser: :firefox_nojs do
+      prepare_user
+      prepare_image
+      login
+
+      initial_downloads = get_my_downloads
+      open_export
+
+      find('.modal').find('.primary-button', text: I18n.t(
+        'media_entry_export_download')).click
+      downloaded_file = get_new_download_file(initial_downloads)
+
+      expect(downloaded_file.basename.to_s).to eq('grumpy_cat.jpg')
+    end
+
+    it 'Check filename preview file', browser: :firefox_nojs do
+      prepare_user
+      prepare_image
+      login
+
+      initial_downloads = get_my_downloads
+      open_export
+
+      find('.modal').all('.icon-dload')[0].click
+      downloaded_file = get_new_download_file(initial_downloads)
+
+      expect(downloaded_file.basename.to_s).to eq('grumpy_cat.jpg.480x360.jpg')
+    end
+
+    it 'Check filename preview file without size', browser: :firefox_nojs do
+      prepare_user
+      prepare_image
+      @media_entry.media_file.previews.each do |preview|
+        preview.width = nil
+        preview.height = nil
+        preview.save
+        preview.reload
+      end
+      login
+
+      initial_downloads = get_my_downloads
+      open_export
+
+      find('.modal').all('.icon-dload')[0].click
+      downloaded_file = get_new_download_file(initial_downloads)
+
+      expect(downloaded_file.basename.to_s).to eq('grumpy_cat.jpg.jpg')
+    end
   end
 
   private


### PR DESCRIPTION
@eins78 Da müsstes du kurz drüber kucken, obs richtig ist das aus den Metadaten zu lesen und ob es richtig ist, die Extension nur zu setzen, wenn der Filename nicht gegeben ist. 