### PR TITLE
Pku master listing fixes

### DIFF
--- a/app/assets/javascripts/lib/metadata-listing-helper.coffee
+++ b/app/assets/javascripts/lib/metadata-listing-helper.coffee
@@ -1,0 +1,29 @@
+f = require('active-lodash')
+
+module.exports = {
+
+  _listingFromContextOrVocab: (contextOrVocab) ->
+    listing = f.get(contextOrVocab, 'context') or f.get(contextOrVocab, 'vocabulary')
+    listingType = f.get(listing, 'type')
+    throw new Error 'Invalid Data!' if (listingType && !f.include(['Context', 'Vocabulary'], listingType))
+    {
+      listing: listing,
+      listingType: listingType
+    }
+
+  _isEmptyMetadataList: (metaData, listing, listingType) ->
+    switch
+      when !f.present(listing)
+        true
+      when listingType is 'Vocabulary'
+        not f.some metaData, f.present
+      else
+        not f.some metaData, (i)-> f.present(i.meta_datum)
+
+
+  _isEmptyContextOrVocab: (contextOrVocab) ->
+    {listing, listingType} = @_listingFromContextOrVocab(contextOrVocab)
+    @_isEmptyMetadataList(contextOrVocab.meta_data, listing, listingType)
+
+
+}

--- a/app/assets/javascripts/react/decorators/MetaDataByListing.cjsx
+++ b/app/assets/javascripts/react/decorators/MetaDataByListing.cjsx
@@ -4,6 +4,8 @@ f = require('active-lodash')
 t = require('../../lib/string-translation')('de')
 MadekPropTypes = require('../lib/madek-prop-types.coffee')
 MetaDataList = require('./MetaDataList.cjsx')
+listingHelper = require('../../lib/metadata-listing-helper.coffee')
+
 
 module.exports = React.createClass
   displayName: 'Deco.MetaDataByListing'
@@ -11,9 +13,17 @@ module.exports = React.createClass
     list: MadekPropTypes.metaDataListing.isRequired
     vocabLinks: React.PropTypes.bool
 
+
   render: ({list, vocabLinks} = @props)->
+
+    onlyListsWithContent = f.filter(
+      list,
+      (contextOrVocab) ->
+        not listingHelper._isEmptyContextOrVocab(contextOrVocab)
+    )
+
     # build the boxes with meta_data lists, 4 per row, skip empty
-    colums = f.chunk(list, 4)
+    colums = f.chunk(onlyListsWithContent, 4)
 
     <div className='meta-data-summary mbl'>
 

--- a/app/assets/javascripts/react/decorators/MetaDataList.cjsx
+++ b/app/assets/javascripts/react/decorators/MetaDataList.cjsx
@@ -12,6 +12,7 @@ MetaDatumValues = require('./MetaDatumValues.cjsx')
 Icon = require('../ui-components/Icon.cjsx')
 
 VocabTitleLink = require('../ui-components/VocabTitleLink.cjsx')
+listingHelper = require('../../lib/metadata-listing-helper.coffee')
 
 
 # TODO: inline Edit - MetaDatumEdit = require('../meta-datum-edit.cjsx')
@@ -31,23 +32,17 @@ module.exports = React.createClass
     showTitle: true
     showFallback: true
 
+
   _listingDataWithFallback: (list, type, showTitle, showFallback) ->
     metaData = f.get(list, 'meta_data')
-    listing = f.get(list, 'context') or f.get(list, 'vocabulary')
-    listingType = f.get(listing, 'type')
-    throw new Error 'Invalid Data!' if (listingType && !f.include(['Context', 'Vocabulary'], listingType))
+
+    {listing, listingType} = listingHelper._listingFromContextOrVocab(list)
 
     throw new Error 'No title!' if showTitle and not f.present(listing.label)
     title = f.get(listing, 'label')
 
     # check for empty list:
-    isEmpty = switch
-      when !f.present(listing)
-        true
-      when listingType is 'Vocabulary'
-        not f.some metaData, f.present
-      else
-        not f.some metaData, (i)-> f.present(i.meta_datum)
+    isEmpty = listingHelper._isEmptyMetadataList(metaData, listing, listingType)
 
     # fallback message if needed and wanted:
     fallbackMsg = if (isEmpty and showFallback)

--- a/app/assets/javascripts/react/decorators/MetaDataList.cjsx
+++ b/app/assets/javascripts/react/decorators/MetaDataList.cjsx
@@ -84,8 +84,13 @@ module.exports = React.createClass
 
       <div className={wrapperClass}>
         {if showTitle
-          {# TODO: vocabulary description, privacy_status}
-          <VocabTitleLink text={title} href={'/vocabulary/' + @props.vocabUuid} separated={true} />
+          if @props.vocabUuid
+            # TODO: vocabulary description, privacy_status
+            <VocabTitleLink text={title} href={'/vocabulary/' + @props.vocabUuid} separated={true} />
+          else
+            <h3 className='title-l separated mbm'>
+              {title}
+            </h3>
         }
         {if type is 'list'
           <MetaDataDefinitionList


### PR DESCRIPTION
@eins78 Ich würde die Logik, welche bestimmt, ob ein Kontext/Vokabular leer ist, in einen Helper auslagern, so dass ich diese Methoden schon in MetaDataByListing verwenden kann und dort schon aussortiere. Ich kann nicht erst in MetaDataList prüfen, ob etwas drin ist, da sonst die Kolonnen/Reihen nicht mehr richtig gefüllt werden. 