### PR TITLE
fix: do not show keyword checkboxes if extensible

### DIFF
--- a/app/assets/javascripts/react/lib/forms/input-keywords.cjsx
+++ b/app/assets/javascripts/react/lib/forms/input-keywords.cjsx
@@ -10,7 +10,7 @@ module.exports = React.createClass
     values: React.PropTypes.array.isRequired
     get: React.PropTypes.shape(
       meta_key: MadekPropTypes.metaKey.isRequired
-      fixed_selection: React.PropTypes.bool.isRequired
+      show_checkboxes: React.PropTypes.bool.isRequired
       keywords: React.PropTypes.arrayOf(MadekPropTypes.keyword)
     ).isRequired
 
@@ -29,17 +29,14 @@ module.exports = React.createClass
       @props.onChange(values)
 
   render: ({name, values, get} = @props)->
-    {meta_key, keywords, fixed_selection} = get
+    {meta_key, keywords, show_checkboxes} = get
     # - "keywords" might be given as possible values
     # - for fixed selections show checkboxes (with possible values)
     #   otherwise the show autocompleter (prefilled with pos. values if given)
 
-    if fixed_selection and !f.present(keywords)
-      throw new Error('Input: No Keywords given for fixed selection!')
-
 
     # show an autocomplete:
-    if !fixed_selection
+    if !show_checkboxes
       params = {meta_key_id: meta_key.uuid}
       # prefill the autocomplete if data was given:
       if keywords
@@ -51,7 +48,7 @@ module.exports = React.createClass
         extensible={meta_key.is_extensible}
         autocompleteConfig={autocompleteConfig}/>
 
-    else # is fixed_selection — checkboxes:
+    else # is show_checkboxes — checkboxes:
       <div className='form-item'>
         {#hidden field needed for broken Rails form serialization}
         <input type='hidden' name={name} value=''/>

--- a/app/presenters/presenters/meta_data/meta_datum_edit.rb
+++ b/app/presenters/presenters/meta_data/meta_datum_edit.rb
@@ -11,14 +11,14 @@ module Presenters
           keywords = meta_key.keywords
 
           # ui should show fixed selection (checkboxes) if less than 16 keywords
-          define_singleton_method :fixed_selection do
-            count = keywords.count
-            count > 0 and count <= 16
+          define_singleton_method :show_checkboxes do
+            return false if meta_key.is_extensible_list
+            keywords.count <= 16
           end
 
           # for non-extensible keywords, include the "first" 50 keywords,
           # used as immediate suggestions (without typing)
-          if self.fixed_selection or !meta_key.is_extensible_list
+          if self.show_checkboxes or !meta_key.is_extensible_list
             define_singleton_method :keywords do
               keywords.limit(50).map do |kw|
                 Presenters::Keywords::KeywordIndex.new(kw)

--- a/spec/features/meta_data/inputs/input_keywords_spec.rb
+++ b/spec/features/meta_data/inputs/input_keywords_spec.rb
@@ -16,7 +16,7 @@ feature 'Resource: MetaDatum' do
   context 'Keywords' do
 
     example 'autocomplete shows empty results message' do
-      meta_key = create_meta_key_keywords
+      meta_key = create_meta_key_keywords(is_extensible_list: true)
       in_the_edit_field(meta_key.label) do
         fill_autocomplete('xxxxxxxxxxxxxxxxxxx')
         expect(
@@ -42,7 +42,7 @@ feature 'Resource: MetaDatum' do
     end
 
     example 'autocomplete styles existing values' do
-      meta_key = create_meta_key_keywords
+      meta_key = create_meta_key_keywords(is_extensible_list: true)
       100.times { FactoryGirl.create(:keyword, meta_key: meta_key) }
       meta_datum = FactoryGirl.create(
         :meta_datum_keywords, meta_key: meta_key, media_entry: @media_entry)
@@ -71,6 +71,55 @@ feature 'Resource: MetaDatum' do
       end
     end
 
+    example 'show checkboxes if not extensible and n <= 16' do
+      meta_key = create_meta_key_keywords(is_extensible_list: false)
+      16.times.map { FactoryGirl.create(:keyword, meta_key: meta_key) }
+
+      in_the_edit_field(meta_key.label) do
+        expect(page).to have_selector('input[type=checkbox]', count: 16)
+      end
+    end
+
+    example 'show autocomplete n prefilled if not extensible and n > 16' do
+      meta_key = create_meta_key_keywords(is_extensible_list: false)
+      24.times.map { FactoryGirl.create(:keyword, meta_key: meta_key) }
+
+      in_the_edit_field(meta_key.label) do
+        expect(page).to have_selector('.ui-autocomplete-holder', count: 1)
+        find('input').click
+        expect(page).to have_selector('.tt-selectable', count: 24)
+      end
+    end
+
+    example 'show autocomplete 50 prefilled if not extensible and n > 50' do
+      meta_key = create_meta_key_keywords(is_extensible_list: false)
+      70.times.map { FactoryGirl.create(:keyword, meta_key: meta_key) }
+
+      in_the_edit_field(meta_key.label) do
+        expect(page).to have_selector('.ui-autocomplete-holder', count: 1)
+        find('input').click
+        expect(page).to have_selector('.tt-selectable', count: 50)
+      end
+    end
+
+    example 'show nothing if not extensible and n == 0' do
+      meta_key = create_meta_key_keywords(is_extensible_list: false)
+
+      in_the_edit_field(meta_key.label) do
+        expect(page).to have_selector('input', count: 0)
+      end
+    end
+
+    example 'show autocomplete not prefilled if extensible and n <= 16' do
+      meta_key = create_meta_key_keywords(is_extensible_list: true)
+      5.times.map { FactoryGirl.create(:keyword, meta_key: meta_key) }
+
+      in_the_edit_field(meta_key.label) do
+        expect(page).to have_selector('.ui-autocomplete-holder', count: 1)
+        find('input').click
+        expect(page).to have_selector('.tt-selectable', count: 0)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
@eins78 Ich denke ich habs nun gefixt. Ich habe am Ende noch umbenannt in show_checkboxes im Presenter. Ich weiss, dass wirs allgemeiner haben wollten, aber irgendwie war fixed_selection einfach auch ungünstig, da fixed_selection eigentlich dasselbe wie not is_extensible_list sein könnte. Nun ist es einfach eindeutig. 